### PR TITLE
add clang-format file to disable formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+Language: Cpp
+DisableFormat: true


### PR DESCRIPTION
The lsp-clangd extension for Sublime Text annoyingly tries to format code on save which we don't want since the copied over single header files are already formatted.

Rant over: this commit disables clang-format for C++ files.