### PR TITLE
simdutf: add Version function to return the current simdutf version

### DIFF
--- a/simdutf.go
+++ b/simdutf.go
@@ -15,9 +15,19 @@ package simdutf
 import "C"
 
 import (
+	"sync"
 	"unicode/utf8"
 	"unsafe"
 )
+
+var versionOnce = sync.OnceValue(func() string {
+	return C.GoString(C.simdutf_version())
+})
+
+// Version returns the version of the linked simdutf library.
+func Version() string {
+	return versionOnce()
+}
 
 // IsASCII reports whether p consists entirely of valid ASCII-encoded runes.
 func IsASCII(p []byte) bool {

--- a/simdutf_ext.cpp
+++ b/simdutf_ext.cpp
@@ -8,3 +8,5 @@ bool validate_ascii(const char *buf, size_t len) {
 bool validate_utf8(const char *buf, size_t len) {
   return simdutf::validate_utf8(buf, len);
 }
+
+const char *simdutf_version(void) { return SIMDUTF_VERSION; }

--- a/simdutf_ext.h
+++ b/simdutf_ext.h
@@ -31,6 +31,13 @@ bool validate_ascii(const char *buf, size_t len);
  */
 bool validate_utf8(const char *buf, size_t len);
 
+/**
+ * Return the version of the linked simdutf library.
+ *
+ * @return the version of the simdutf library.
+ */
+const char *simdutf_version(void);
+
 #ifdef __cplusplus
 }
 #endif // __cplusplus

--- a/simdutf_test.go
+++ b/simdutf_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -46,6 +47,22 @@ func init() {
 			in:  prefix + t.in,
 			out: t.out,
 		})
+	}
+}
+
+func TestVersion(t *testing.T) {
+	ver := Version()
+	match, err := regexp.MatchString(`^\d+\.\d+\.\d+$`, ver)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !match {
+		t.Errorf("invalid version: %q", ver)
+	}
+
+	allocs := testing.AllocsPerRun(100, func() { Version() })
+	if allocs != 0 {
+		t.Fatalf("expected 0 allocs per-run got: %.2f", allocs)
 	}
 }
 


### PR DESCRIPTION
This commit adds the Version function which returns the version of the linked simdutf library.